### PR TITLE
Fix subscription schedule

### DIFF
--- a/app/services/stripe_model_callbacks/subscription_schedule/updated_service.rb
+++ b/app/services/stripe_model_callbacks/subscription_schedule/updated_service.rb
@@ -10,7 +10,7 @@ class StripeModelCallbacks::SubscriptionSchedule::UpdatedService < StripeModelCa
 
     return success_actions if subscription_schedule.save
 
-    fail!(invoice.subscription_schedule.full_messages)
+    fail!(subscription_schedule.errors.full_messages)
   end
 
 private

--- a/db/migrate/20200520152604_change_stripe_subscription_schedule_phase_id_to_bigint.rb
+++ b/db/migrate/20200520152604_change_stripe_subscription_schedule_phase_id_to_bigint.rb
@@ -1,5 +1,17 @@
 class ChangeStripeSubscriptionSchedulePhaseIdToBigint < ActiveRecord::Migration[6.0]
   def change
-    change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint # USING stripe_subscription_schedule_phase_id::bigint
+    if postgres?
+      change_column(
+        :stripe_subscription_schedule_phase_plans,
+        :stripe_subscription_schedule_phase_id,
+        "bigint USING stripe_subscription_schedule_phase_id::bigint"
+      )
+    else
+      change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint
+    end
+  end
+
+  def postgres?
+    %w[PostGIS Postgres].include?(ActiveRecord::Base.connection.adapter_name)
   end
 end

--- a/db/migrate/20200520152604_change_stripe_subscription_schedule_phase_id_to_bigint.rb
+++ b/db/migrate/20200520152604_change_stripe_subscription_schedule_phase_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangeStripeSubscriptionSchedulePhaseIdToBigint < ActiveRecord::Migration[6.0]
+  def change
+    change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint # USING stripe_subscription_schedule_phase_id::bigint
+  end
+end

--- a/lib/stripe_model_callbacks/models/stripe_customer.rb
+++ b/lib/stripe_model_callbacks/models/stripe_customer.rb
@@ -6,6 +6,7 @@ class StripeCustomer < StripeModelCallbacks::ApplicationRecord
   has_many :stripe_invoice_items, primary_key: "stripe_id"
   has_many :stripe_orders, primary_key: "stripe_id"
   has_many :stripe_subscriptions, primary_key: "stripe_id"
+  has_many :stripe_subscription_schedules, primary_key: "stripe_id"
 
   def self.stripe_class
     Stripe::Customer

--- a/lib/stripe_model_callbacks/models/stripe_subscription.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription.rb
@@ -5,6 +5,7 @@ class StripeSubscription < StripeModelCallbacks::ApplicationRecord
   has_many :stripe_invoices, primary_key: "stripe_id"
   has_many :stripe_discounts, primary_key: "stripe_id"
   has_many :stripe_subscription_items, autosave: true, primary_key: "stripe_id"
+  has_many :stripe_subscription_schedules, primary_key: "stripe_id"
   has_many :stripe_plans, through: :stripe_subscription_items
 
   STATES = %w[trialing active past_due canceled unpaid].freeze

--- a/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
@@ -9,7 +9,7 @@ class StripeSubscriptionSchedule < StripeModelCallbacks::ApplicationRecord
   private_constant :MATCHING_STRIPE_ATTRIBUTES
 
   belongs_to :stripe_customer, primary_key: "stripe_id"
-  belongs_to :stripe_subscription, primary_key: "stripe_id"
+  belongs_to :stripe_subscription, primary_key: "stripe_id", optional: true
 
   has_many :stripe_subscription_schedule_phases, primary_key: "stripe_id", dependent: :destroy
 

--- a/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
@@ -8,8 +8,8 @@ class StripeSubscriptionSchedule < StripeModelCallbacks::ApplicationRecord
   ].freeze
   private_constant :MATCHING_STRIPE_ATTRIBUTES
 
-  belongs_to :stripe_customer, primary_key: "stripe_id"
-  belongs_to :stripe_subscription, primary_key: "stripe_id", optional: true
+  belongs_to :stripe_customer, optional: true, primary_key: "stripe_id"
+  belongs_to :stripe_subscription, optional: true, primary_key: "stripe_id"
 
   has_many :stripe_subscription_schedule_phases, primary_key: "stripe_id", dependent: :destroy
 

--- a/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription_schedule.rb
@@ -2,7 +2,7 @@ class StripeSubscriptionSchedule < StripeModelCallbacks::ApplicationRecord
   MATCHING_STRIPE_ATTRIBUTES = %w[
     billing created collection_method
     default_payment_method default_source
-    end_behavior metadata livemode
+    end_behavior id metadata livemode
     renewal_behavior renewal_interval
     status
   ].freeze

--- a/lib/stripe_model_callbacks/models/stripe_subscription_schedule_phase_plan.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription_schedule_phase_plan.rb
@@ -2,7 +2,7 @@ class StripeSubscriptionSchedulePhasePlan < ApplicationRecord
   MATCHING_STRIPE_ATTRIBUTES = %w[quantity].freeze
   private_constant :MATCHING_STRIPE_ATTRIBUTES
 
-  belongs_to :stripe_plan, primary_key: "stripe_id"
+  belongs_to :stripe_plan, optional: true, primary_key: "stripe_id"
   belongs_to :stripe_subscription_schedule_phase
 
   has_one :stripe_subscription_schedule, through: :stripe_subscription_schedule_phase

--- a/lib/stripe_model_callbacks/models/stripe_subscription_schedule_phase_plan.rb
+++ b/lib/stripe_model_callbacks/models/stripe_subscription_schedule_phase_plan.rb
@@ -2,6 +2,7 @@ class StripeSubscriptionSchedulePhasePlan < ApplicationRecord
   MATCHING_STRIPE_ATTRIBUTES = %w[quantity].freeze
   private_constant :MATCHING_STRIPE_ATTRIBUTES
 
+  belongs_to :stripe_plan, primary_key: "stripe_id"
   belongs_to :stripe_subscription_schedule_phase
 
   has_one :stripe_subscription_schedule, through: :stripe_subscription_schedule_phase

--- a/spec/dummy/db/migrate/20200520152659_change_stripe_subscription_schedule_phase_id_to_bigint.stripe_model_callbacks.rb
+++ b/spec/dummy/db/migrate/20200520152659_change_stripe_subscription_schedule_phase_id_to_bigint.stripe_model_callbacks.rb
@@ -1,6 +1,18 @@
 # This migration comes from stripe_model_callbacks (originally 20200520152604)
 class ChangeStripeSubscriptionSchedulePhaseIdToBigint < ActiveRecord::Migration[6.0]
   def change
-    change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint
+    if postgres?
+      change_column(
+        :stripe_subscription_schedule_phase_plans,
+        :stripe_subscription_schedule_phase_id,
+        "bigint USING stripe_subscription_schedule_phase_id::bigint"
+      )
+    else
+      change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint
+    end
+  end
+
+  def postgres?
+    %w[PostGIS Postgres].include?(ActiveRecord::Base.connection.adapter_name)
   end
 end

--- a/spec/dummy/db/migrate/20200520152659_change_stripe_subscription_schedule_phase_id_to_bigint.stripe_model_callbacks.rb
+++ b/spec/dummy/db/migrate/20200520152659_change_stripe_subscription_schedule_phase_id_to_bigint.stripe_model_callbacks.rb
@@ -1,0 +1,6 @@
+# This migration comes from stripe_model_callbacks (originally 20200520152604)
+class ChangeStripeSubscriptionSchedulePhaseIdToBigint < ActiveRecord::Migration[6.0]
+  def change
+    change_column :stripe_subscription_schedule_phase_plans, :stripe_subscription_schedule_phase_id, :bigint
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_15_103042) do
+ActiveRecord::Schema.define(version: 2020_05_20_152659) do
 
   create_table "activities", force: :cascade do |t|
     t.string "trackable_type"
@@ -626,7 +626,7 @@ ActiveRecord::Schema.define(version: 2020_05_15_103042) do
   end
 
   create_table "stripe_subscription_schedule_phase_plans", force: :cascade do |t|
-    t.string "stripe_subscription_schedule_phase_id", null: false
+    t.bigint "stripe_subscription_schedule_phase_id", null: false
     t.integer "billing_thresholds_usage_gte"
     t.string "stripe_plan_id"
     t.string "stripe_price_id"


### PR DESCRIPTION
Fixes:
- wrong variable name on fail! in SubscriptionSchedule::UpdatedService
- stripe_subscription_schedule_phase_id has wrong type. -> Only returns error on Postgres
- make sure stripe id is assigned for StripeSubscriptionSchedule

Misc:
- Add missing associations